### PR TITLE
fix: changed ssh key to https request

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "candle"]
 	path = candle
-	url = git@github.com:mabrobotics/candle.git
+	url = https://github.com/mabrobotics/candle.git


### PR DESCRIPTION
ssh key pull is not possible if ssh identity isn't assigned to any github account therefore https request is preferable for public repositories